### PR TITLE
Rename Lazy' => Delayed

### DIFF
--- a/libs/prelude/Prelude/Stream.idr
+++ b/libs/prelude/Prelude/Stream.idr
@@ -13,8 +13,8 @@ import Prelude.List
 %default total
 
 ||| An infinite stream
-codata Stream : Type -> Type where
-  (::) : (e : a) -> Stream a -> Stream a
+data Stream : Type -> Type where
+  (::) : (e : a) -> Inf (Stream a) -> Stream a
 
 -- Hints for interactive editing
 %name Stream xs,ys,zs,ws

--- a/src/Idris/Core/Unify.hs
+++ b/src/Idris/Core/Unify.hs
@@ -712,9 +712,9 @@ envPos x i ((y, _) : ys) | x == y = i
 -- Issue #1722 on the issue tracker https://github.com/idris-lang/Idris-dev/issues/1722
 --
 recoverable t@(App _ _ _) _
-    | (P _ (UN l) _, _) <- unApply t, l == txt "Lazy'" = False
+    | (P _ (UN l) _, _) <- unApply t, l == txt "Delayed" = False
 recoverable _ t@(App _ _ _)
-    | (P _ (UN l) _, _) <- unApply t, l == txt "Lazy'" = False
+    | (P _ (UN l) _, _) <- unApply t, l == txt "Delayed" = False
 recoverable (P (DCon _ _ _) x _) (P (DCon _ _ _) y _) = x == y
 recoverable (P (TCon _ _) x _) (P (TCon _ _) y _) = x == y
 recoverable (TType _) (P (DCon _ _ _) y _) = False

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -493,9 +493,9 @@ delazy' all t@(App _ f a)
      | (P _ (UN l) _, [_, _, arg]) <- unApply t,
        l == txt "Force" = delazy' all arg
      | (P _ (UN l) _, [P _ (UN lty) _, _, arg]) <- unApply t,
-       l == txt "Delay" && (all || lty == txt "LazyEval") = delazy arg
+       l == txt "Delay" && (all || lty /= txt "Infinite") = delazy arg
      | (P _ (UN l) _, [P _ (UN lty) _, arg]) <- unApply t,
-       l == txt "Lazy'" && (all || lty == txt "LazyEval") = delazy' all arg
+       l == txt "Delayed" && (all || lty /= txt "Infinite") = delazy' all arg
 delazy' all (App s f a) = App s (delazy' all f) (delazy' all a)
 delazy' all (Bind n b sc) = Bind n (fmap (delazy' all) b) (delazy' all sc)
 delazy' all t = t

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -216,8 +216,8 @@ elabCon info syn tn codata expkind dkind (doc, argDocs, n, nfc, t_in, fc, forcen
 
     mkLazy (PPi pl n nfc ty sc)
         = let ty' = if getTyName ty
-                       then PApp fc (PRef fc [] (sUN "Lazy'"))
-                            [pexp (PRef fc [] (sUN "LazyCodata")),
+                       then PApp fc (PRef fc [] (sUN "Delayed"))
+                            [pexp (PRef fc [] (sUN "Infinite")),
                              pexp ty]
                        else ty in
               PPi pl n nfc ty' (mkLazy sc)

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -313,13 +313,13 @@ elab ist info emode opts fn tm
 
     forceErr orig env (CantUnify _ (t,_) (t',_) _ _ _)
        | (P _ (UN ht) _, _) <- unApply (normalise (tt_ctxt ist) env t),
-            ht == txt "Lazy'" = notDelay orig
+            ht == txt "Delayed" = notDelay orig
     forceErr orig env (CantUnify _ (t,_) (t',_) _ _ _)
        | (P _ (UN ht) _, _) <- unApply (normalise (tt_ctxt ist) env t'),
-            ht == txt "Lazy'" = notDelay orig
+            ht == txt "Delayed" = notDelay orig
     forceErr orig env (InfiniteUnify _ t _)
        | (P _ (UN ht) _, _) <- unApply (normalise (tt_ctxt ist) env t),
-            ht == txt "Lazy'" = notDelay orig
+            ht == txt "Delayed" = notDelay orig
     forceErr orig env (Elaborating _ _ _ t) = forceErr orig env t
     forceErr orig env (ElaboratingArg _ _ _ t) = forceErr orig env t
     forceErr orig env (At _ t) = forceErr orig env t
@@ -482,7 +482,7 @@ elab ist info emode opts fn tm
                      return $ pruneByType env tc (unDelay ty) ist as
 
               unDelay t | (P _ (UN l) _, [_, arg]) <- unApply t,
-                          l == txt "Lazy'" = unDelay arg
+                          l == txt "Delayed" = unDelay arg
                         | otherwise = t
 
               isAmbiguous (CantResolveAlts _) = delayok
@@ -1400,7 +1400,7 @@ elab ist info emode opts fn tm
            let (tyh, _) = unApply (normalise (tt_ctxt ist) env ty)
            let tries = [mkDelay env t, t]
            case tyh of
-                P _ (UN l) _ | l == txt "Lazy'"
+                P _ (UN l) _ | l == txt "Delayed"
                     -> return (PAlternative [] FirstSuccess tries)
                 _ -> return t
       where

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -101,10 +101,10 @@ typeFromDef (def, _, _, _, _) = get def where
   get (CaseOp _ ty _ _ _ _)  = Just ty
   get _ = Nothing
 
--- Replace all occurences of `Lazy' s t` with `t` in a type
+-- Replace all occurences of `Delayed s t` with `t` in a type
 unLazy :: Type -> Type
 unLazy typ = case typ of
-  App _ (App _ (P _ lazy _) _) ty | lazy == sUN "Lazy'" -> unLazy ty
+  App _ (App _ (P _ lazy _) _) ty | lazy == sUN "Delayed" -> unLazy ty
   Bind name binder ty -> Bind name (fmap unLazy binder) (unLazy ty)
   App s t1 t2 -> App s (unLazy t1) (unLazy t2)
   Proj ty i -> Proj (unLazy ty) i


### PR DESCRIPTION
There may be reasons for delaying a computation other than it being
Lazy (e.g. asynchronous calls may be nice one day). Also, we should
avoid terms like 'codata' or 'coinduction' in the library, when in
practice it's really about creating infinite structures.